### PR TITLE
Fix the regular expression of tag names

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -84,7 +84,7 @@ def lambda_handler(event, context):
     else:
         errorissue(REPO_FULLNAME, AUTHOR, "The repository does not have a .jl suffix.")
 
-    if not re.match(r"v\d+.\d+.\d+", TAG_NAME):
+    if not re.match(r"v\d+\.\d+\.\d+", TAG_NAME):
         errorissue(REPO_FULLNAME, AUTHOR, "The tag name \"" + TAG_NAME + "\" is not of the appropriate SemVer form (vX.Y.Z).")
 
     VERSION = TAG_NAME[1:]


### PR DESCRIPTION
The current regular expression has false positives, so I fixed it.

```
In [7]: re.match(r"v\d+.\d+.\d+", "v1x2x3")
Out[7]: <_sre.SRE_Match at 0x10f382d98>

In [8]: re.match(r"v\d+\.\d+\.\d+", "v1x2x3")

In [9]: re.match(r"v\d+\.\d+\.\d+", "v1.2.3")
Out[9]: <_sre.SRE_Match at 0x10f382d30>
```