### PR TITLE
Ensure the requires diff is newline-terminated

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -288,6 +288,9 @@ def lambda_handler(event, context):
         if req_diff == "":
             req_status = "no changes"
         else:
+            # Ensure closing ``` is on its own line
+            if not req_diff.endswith("\n"):
+                req_diff += "\n"
             req_status = "\n```diff\n" + req_diff + "```"
 
         title = "Tag " + REPO_NAME + " " + TAG_NAME


### PR DESCRIPTION
This should fix cases where the triple backquote that ends markdown code
blocks isn't on its own line. In such cases, the code block doesn't
properly terminate, so the cc: author line is consumed into the block.

Fixes #9