### PR TITLE
adjust tag message about version bounds

### DIFF
--- a/AttoBot/lambda_function.py
+++ b/AttoBot/lambda_function.py
@@ -28,7 +28,7 @@ SECRET = os.environ["SECRET"]
 TAG_REQ = "\n".join((
     "Please make sure that:",
     "- CI passes for supported Julia versions (if applicable).",
-    "- Version bounds are up to date."
+    "- Version bounds reflect minimum requirements."
 ))
 
 # seems like the best option is to base64 encode the body?


### PR DESCRIPTION
"up to date" could be confusingly interpreted as "latest versions"
which isn't usually appropriate