### PR TITLE
Remove broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AttoBot is a package release bot for Julia. It creates pull requests to Julia ME
 
 To set up AttoBot on your repository, go to https://github.com/integration/attobot and click "Configure" to select the repositories you wish to add. It will only operate on packages with the standard ".jl" suffix (all other packages will be ignored).
 
-If the package is not yet [registered in METADATA.jl](http://docs.julialang.org/en/stable/manual/packages/#tagging-and-publishing-your-package), it will be automatically added when you make your first release.
+If the package is not yet registered in METADATA.jl, it will be automatically added when you make your first release.
 
 ### Creating a release
 Releases are created via [GitHub releases](https://help.github.com/articles/creating-releases/): this is some extra functionality built on top of git tags that trigger a webhook used by AttoBot.


### PR DESCRIPTION
Removing link since the old way of doing thing is a dead end since Pkg3.register doesn't exist.  Removing the link gets rid of confusion.